### PR TITLE
Utilise atan2 pour calculer le roll. 

### DIFF
--- a/sara_flexbe_states/src/sara_flexbe_states/GetGraspFromEntity.py
+++ b/sara_flexbe_states/src/sara_flexbe_states/GetGraspFromEntity.py
@@ -143,9 +143,15 @@ class GetGraspFromEntity(EventState):
             yaw = math.atan2(grasp.approach.y, grasp.approach.x)
             pitch = -math.atan2(grasp.approach.z, math.sqrt(
                 (grasp.approach.x * grasp.approach.x) + (grasp.approach.y * grasp.approach.y)))
+
+            approach = [grasp.approach.x, grasp.approach.y, grasp.approach.z]
+            approach /= (approach**2).sum()**0.5  # Get the unit vector
             binormal = [grasp.binormal.x, grasp.binormal.y, grasp.binormal.z]
-            binormal_ref = np.cross([0, 0, 1], [grasp.approach.x, grasp.approach.y, grasp.approach.z])
-            roll = math.acos(np.dot(binormal, binormal_ref) / (np.linalg.norm(binormal) * np.linalg.norm(binormal_ref)))
+            binormal /= (binormal**2).sum()**0.5  # Get the unit vector
+
+            binormal_ref_x = np.cross([0, 0, 1], approach)
+            binormal_ref_y = np.cross(binormal_ref_x, approach)
+            roll = math.atan2(np.vdot(approach, binormal_ref_y), np.vdot(approach, binormal_ref_x))
 
             #if roll > math.pi / 2:
             #    roll = roll - math.pi


### PR DESCRIPTION
Cette formule devrais mieux supporter les angles de +- 180°

Le truc, c'est de se créer deux références à 90° l'une de l’autre pour se retrouver avec un nouveaux frame de référence. Il suffit ensuite de faire le produit scalaire du vecteur binormal sur ces références pour en tirer les composantes et pouvoir utiliser atan2.

Ça reste à tester par contre